### PR TITLE
feat: Adding CI detection

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -179,6 +179,13 @@ func TestSkipTestWithinGroup(t *testing.T) {
 }
 
 func TestRunOnlyOneWithinGroup(t *testing.T) {
+
+	t.Setenv(odize.ENV_CI, "false")
+
+	defer func() {
+		t.Setenv(odize.ENV_CI, "true")
+	}()
+
 	group := odize.NewGroup(t, nil)
 	err := group.
 		Test("should equal 1", func(t *testing.T) {

--- a/odize_test.go
+++ b/odize_test.go
@@ -288,6 +288,12 @@ func TestOptionSkip(t *testing.T) {
 }
 
 func TestOptionOnly(t *testing.T) {
+	t.Setenv(ENV_CI, "false")
+
+	defer func() {
+		t.Setenv(ENV_CI, "true")
+	}()
+
 	tg := NewGroup(t, nil)
 
 	testCall := 0
@@ -302,6 +308,7 @@ func TestOptionOnly(t *testing.T) {
 		Run()
 	AssertNoError(t, err)
 	AssertEqual(t, 1, testCall)
+
 }
 
 func TestCITest(t *testing.T) {

--- a/odize_test.go
+++ b/odize_test.go
@@ -1,6 +1,7 @@
 package odize
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -301,4 +302,41 @@ func TestOptionOnly(t *testing.T) {
 		Run()
 	AssertNoError(t, err)
 	AssertEqual(t, 1, testCall)
+}
+
+func TestCITest(t *testing.T) {
+	t.Setenv(ENV_CI, "true")
+
+	defer func() {
+		t.Setenv(ENV_CI, "false")
+	}()
+
+	tg := NewGroup(t, nil)
+
+	err := tg.
+		Test("should fail group if ENV_CI is true", func(t *testing.T) {
+			AssertTrue(t, true)
+		}, Only()).
+		Test("should not execute test", func(t *testing.T) {
+			AssertTrue(t, false)
+		}).
+		Run()
+	AssertTrue(t, errors.Is(err, ErrTestOptionNotAllowedInCI))
+}
+
+func TestCITestNoOnly(t *testing.T) {
+	t.Setenv(ENV_CI, "true")
+
+	defer func() {
+		t.Setenv(ENV_CI, "false")
+	}()
+
+	tg := NewGroup(t, nil)
+
+	err := tg.
+		Test("should pass", func(t *testing.T) {
+			AssertTrue(t, true)
+		}).
+		Run()
+	AssertNoError(t, err)
 }

--- a/types.go
+++ b/types.go
@@ -18,6 +18,7 @@ type TestGroup struct {
 	registry   []TestRegistryEntry
 	cache      map[string]struct{}
 	errors     ErrorList
+	isCIEnv    bool
 }
 
 // TestFn - Test function


### PR DESCRIPTION
Adding CI detection into the test group:
- Env var "CI" is set as a `true` in [github actions](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables).
- If odize detects it is in a CI environment, and the group of tests has a test option of 'Only', It will fail the group with a message. 
- Note that the Test option 'Skip' will not cause a failure.